### PR TITLE
Refactor Kafka connection handling and perform internal queueing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel 0.4.2",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils 0.7.2",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +275,16 @@ dependencies = [
  "maybe-uninit",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -499,6 +523,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "crossbeam",
  "dipstick",
  "futures",
  "handlebars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ syslog_rfc5424 = "~0.6.1"
 async-tls = "~0.7.0"
 rustls = "~0.17.0"
 
+# Requiredfor communciating with across internal queues
+crossbeam = "~0.7"
+
 # Needed for forwarding messages along to Kafka
 # including the SSL and SASL features to ensure that this can authenticate
 # against secure Kafka clusters, e.g. AWS MSK

--- a/README.adoc
+++ b/README.adoc
@@ -131,12 +131,16 @@ global:
 queue for sending messages to Kafka. This queue represents the number of
 internal messages `hotdog` will buffer during Kafka availability issues.
 
+This value is *not* the same as the librdkafka `queue.buffering.max.messages`
+configuration, which governs the number of in-flight messages which can be sent
+at any given time to the Kafka broker(s). To set that variable, include it in
+the <<yml-kafka-conf>> section documented below.
+
 [CAUTION]
 ====
 If the internal Kafka queue has been filled up, new log lines received by
 `hotdog` will be discarded.
 ====
-
 
 [[yml-kafka-conf]]
 ===== Conf
@@ -146,6 +150,15 @@ link:https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md[librdka
 `hotdog` will expect every key _and_ value to be a String. These configuration
 values are passed right on to the underlying librdkafka client connection, so
 whatever librdkafka supports, `hotdog` supports!
+
+[[yml-kafka-timeout_ms]]
+===== timeout_ms
+
+**Default:** `30_000`
+
+`global.kafka.timeout_ms` is an optional configuration which defines the
+timeout in milliseconds for `hotdog` to make an initial connection to the
+configured Kafka brokers.
 
 [[yml-kafka-topic]]
 ===== Topic

--- a/README.adoc
+++ b/README.adoc
@@ -122,6 +122,22 @@ global:
     topic: 'logs'
 ----
 
+[[yml-kafka-buffer]]
+===== Buffer
+
+**Default:** `1024`
+
+`global.kafka.buffer` may contain a number indicating the size of the internal
+queue for sending messages to Kafka. This queue represents the number of
+internal messages `hotdog` will buffer during Kafka availability issues.
+
+[CAUTION]
+====
+If the internal Kafka queue has been filled up, new log lines received by
+`hotdog` will be discarded.
+====
+
+
 [[yml-kafka-conf]]
 ===== Conf
 
@@ -130,6 +146,12 @@ link:https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md[librdka
 `hotdog` will expect every key _and_ value to be a String. These configuration
 values are passed right on to the underlying librdkafka client connection, so
 whatever librdkafka supports, `hotdog` supports!
+
+[[yml-kafka-topic]]
+===== Topic
+
+`global.kafka.topic` may contain a string value which is to be considered the
+"default topic" for the <<action-forward, Forward action>>.
 
 
 [[yml-metrics]]

--- a/hotdog.yml
+++ b/hotdog.yml
@@ -11,6 +11,9 @@ global:
     #port: 1514
     #tls:
   kafka:
+    # Maximum number of messages to buffer internally while waiting for Kafka
+    # responses
+    buffer: 1024
     conf:
       bootstrap.servers: '127.0.0.1:9092'
     # Default topic to log messages to that are not otherwise mapped

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -1,0 +1,152 @@
+/**
+ * The Kafka module contains all the tooling/code necessary for connecting hotdog to Kafka for
+ * sending log lines along as Kafka messages
+ */
+
+use crossbeam::channel::{Sender, Receiver, bounded};
+use log::*;
+use rdkafka::config::ClientConfig;
+use rdkafka::client::DefaultClientContext;
+use rdkafka::consumer::{BaseConsumer, Consumer};
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use std::collections::HashMap;
+use std::time::Duration;
+
+/**
+ * KafkaMessage just carries a message and its destination topic between tasks
+ */
+pub struct KafkaMessage {
+    topic: String,
+    msg: String,
+}
+
+impl KafkaMessage {
+    pub fn new(topic: String, msg: String) -> KafkaMessage {
+        KafkaMessage {
+            topic,
+            msg,
+        }
+    }
+}
+
+/**
+ * The Kafka struct acts as the primary interface between hotdog and Kafka
+ */
+pub struct Kafka {
+    /*
+     * I'm not super thrilled about wrapping the FutureProducer in an option, but it's the only way
+     * that I can think to create an effective two-phase construction of this struct between
+     * ::new() and the .connect() function
+     */
+    producer: Option<FutureProducer<DefaultClientContext>>,
+    rx: Receiver<KafkaMessage>,
+    tx: Sender<KafkaMessage>,
+}
+
+impl Kafka {
+    pub fn new(message_max: usize) -> Kafka {
+        let (tx, rx) = bounded(message_max);
+        Kafka {
+            producer: None,
+            tx,
+            rx,
+        }
+    }
+
+    /**
+     * connect() will inherently validate the configuration and perform a blocking call to the
+     * configured bootstrap.servers in order to determine whether Kafka is reachable.
+     *
+     * Assuming Kafka can be reached, the connect() call will construct the producer and return
+     * true
+     *
+     * If timeout_ms is not specified, a default 10s timeout will be used
+     */
+    pub fn connect(&mut self, rdkafka_conf: &HashMap<String, String>, timeout_ms: Option<Duration>) -> bool {
+        let mut rd_conf = ClientConfig::new();
+        for (key, value) in rdkafka_conf.iter() {
+            rd_conf.set(key, value);
+        }
+
+        let consumer: BaseConsumer = rd_conf.create().expect("Creation of Kafka consumer (for metadata) failed");
+
+        let timeout = match timeout_ms {
+            Some(ms) => {
+                ms
+            },
+            None => {
+                Duration::from_secs(10)
+            },
+        };
+
+        if let Ok(metadata) = consumer.fetch_metadata(None, timeout) {
+            debug!("  Broker count: {}", metadata.brokers().len());
+            debug!("  Topics count: {}", metadata.topics().len());
+            debug!("  Metadata broker name: {}", metadata.orig_broker_name());
+            debug!("  Metadata broker id: {}\n", metadata.orig_broker_id());
+
+            self.producer = Some(rd_conf.create().expect("Failed to create the Kafka producer!"));
+
+            return true;
+        }
+
+        warn!("Failed to connect to a Kafka broker");
+
+        return false;
+    }
+
+    /**
+     * get_sender() will return a cloned reference to the sender suitable for tasks or threads to
+     * consume and take ownership of
+     */
+    pub fn get_sender(&self) -> Sender<KafkaMessage> {
+        self.tx.clone()
+    }
+
+    /**
+     * sendloop should be called in a thread/task and will never return
+     */
+    pub fn sendloop(&self) -> ! {
+        if self.producer.is_none() {
+            panic!("Cannot enter the sendloop() without a valid producer");
+        }
+
+        let producer = self.producer.as_ref().unwrap();
+
+        // How long should we wait for an internal message to show up on our channel
+        let timeout_ms = Duration::from_millis(100);
+
+        // TODO: replace me with a select
+        loop {
+            if let Ok(kmsg) = self.rx.recv_timeout(timeout_ms) {
+                let record = FutureRecord::to(&kmsg.topic).payload(&kmsg.msg).key(&kmsg.msg);
+
+                /*
+                 * Intentionally setting the timeout_ms to -1 here so this blocks forever if the
+                 * outbound librdkafka queue is full. This will block up the crossbeam channel
+                 * properly and cause messages to begin to be dropped, rather than buffering
+                 * "forever" inside of hotdog
+                 */
+                let _future = producer.send(record, -1 as i64);
+            }
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /**
+     * Test that trying to connect to a nonexistent cluster returns false
+     */
+    #[test]
+    fn test_connect_bad_cluster() {
+        let mut conf = HashMap::<String, String>::new();
+        conf.insert(String::from("bootstrap.servers"), String::from("example.com:9092"));
+
+        let mut k = Kafka::new(0);
+        assert_eq!(false, k.connect(&conf, Some(Duration::from_secs(1))));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
+extern crate chrono;
 /**
  * hotdog's main
  */
 extern crate clap;
-extern crate chrono;
 extern crate config;
 extern crate dipstick;
 extern crate handlebars;
@@ -23,8 +23,8 @@ use async_std::{
     sync::Arc,
     task,
 };
-use clap::{Arg, App};
 use chrono::prelude::*;
+use clap::{App, Arg};
 use crossbeam::channel::Sender;
 use dipstick::*;
 use handlebars::Handlebars;
@@ -35,11 +35,11 @@ use syslog_rfc5424::parse_message;
 mod kafka;
 mod merge;
 mod rules;
-mod settings;
 mod serve_tls;
+mod settings;
 
-use settings::*;
 use kafka::{Kafka, KafkaMessage};
+use settings::*;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -65,23 +65,27 @@ fn main() -> Result<()> {
     pretty_env_logger::init();
 
     let matches = App::new("Hotdog")
-                          .version(env!("CARGO_PKG_VERSION"))
-                          .author("R Tyler Croy <rtyler+hotdog@brokenco.de")
-                          .about("Forward syslog over to Kafka with ease")
-                          .arg(Arg::with_name("config")
-                               .short("c")
-                               .long("config")
-                               .value_name("FILE")
-                               .help("Sets a custom config file")
-                               .default_value("hotdog.yml")
-                               .takes_value(true))
-                          .arg(Arg::with_name("test")
-                              .short("t")
-                              .long("test")
-                              .value_name("TEST_FILE")
-                              .help("Test a log file against the configured rules")
-                              .takes_value(true))
-                          .get_matches();
+        .version(env!("CARGO_PKG_VERSION"))
+        .author("R Tyler Croy <rtyler+hotdog@brokenco.de")
+        .about("Forward syslog over to Kafka with ease")
+        .arg(
+            Arg::with_name("config")
+                .short("c")
+                .long("config")
+                .value_name("FILE")
+                .help("Sets a custom config file")
+                .default_value("hotdog.yml")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("test")
+                .short("t")
+                .long("test")
+                .value_name("TEST_FILE")
+                .help("Test a log file against the configured rules")
+                .takes_value(true),
+        )
+        .get_matches();
 
     let settings_file = matches.value_of("config").unwrap_or("hotdog.yml");
     let settings = Arc::new(settings::load(settings_file));
@@ -90,10 +94,12 @@ fn main() -> Result<()> {
         return task::block_on(rules::test_rules(&test_file, settings.clone()));
     }
 
-    let metrics = Arc::new(Statsd::send_to(&settings.global.metrics.statsd)
-        .expect("Failed to create Statsd recorder")
-        .named("hotdog")
-        .metrics());
+    let metrics = Arc::new(
+        Statsd::send_to(&settings.global.metrics.statsd)
+            .expect("Failed to create Statsd recorder")
+            .named("hotdog")
+            .metrics(),
+    );
 
     let addr = format!(
         "{}:{}",
@@ -104,26 +110,34 @@ fn main() -> Result<()> {
     match &settings.global.listen.tls {
         TlsType::CertAndKey { cert: _, key: _ } => {
             info!("Serving in TLS mode");
-            task::block_on(
-                crate::serve_tls::accept_loop(addr, settings.clone(), metrics.clone()))
-        },
+            task::block_on(crate::serve_tls::accept_loop(
+                addr,
+                settings.clone(),
+                metrics.clone(),
+            ))
+        }
         _ => {
             info!("Serving in plaintext mode");
-            task::block_on(
-                accept_loop(addr, settings.clone(), metrics.clone()))
-        },
+            task::block_on(accept_loop(addr, settings.clone(), metrics.clone()))
+        }
     }
 }
-
 
 /**
  * accept_loop will simply create the socket listener and dispatch newly accepted connections to
  * the connection_loop function
  */
-async fn accept_loop(addr: impl ToSocketAddrs, settings: Arc<Settings>, metrics: Arc<LockingOutput>) -> Result<()> {
+async fn accept_loop(
+    addr: impl ToSocketAddrs,
+    settings: Arc<Settings>,
+    metrics: Arc<LockingOutput>,
+) -> Result<()> {
     let mut kafka = Kafka::new(settings.global.kafka.buffer);
 
-    if ! kafka.connect(&settings.global.kafka.conf, Some(settings.global.kafka.timeout_ms)) {
+    if !kafka.connect(
+        &settings.global.kafka.conf,
+        Some(settings.global.kafka.timeout_ms),
+    ) {
         error!("Cannot start hotdog without a workable broker connection");
         return Ok(());
     }
@@ -161,7 +175,10 @@ async fn accept_loop(addr: impl ToSocketAddrs, settings: Arc<Settings>, metrics:
  *
  */
 
-pub async fn read_logs<R: async_std::io::Read + std::marker::Unpin>(reader: BufReader<R>, state: ConnectionState) -> Result<()> {
+pub async fn read_logs<R: async_std::io::Read + std::marker::Unpin>(
+    reader: BufReader<R>,
+    state: ConnectionState,
+) -> Result<()> {
     let mut lines = reader.lines();
     let lines_count = state.metrics.counter("lines");
 
@@ -176,8 +193,8 @@ pub async fn read_logs<R: async_std::io::Read + std::marker::Unpin>(reader: BufR
         match &parsed {
             Err(e) => {
                 error!("failed to parse message: {}", e);
-            },
-            _ => {},
+            }
+            _ => {}
         }
 
         /*
@@ -192,7 +209,7 @@ pub async fn read_logs<R: async_std::io::Read + std::marker::Unpin>(reader: BufR
              * If we have been told to stop processing rules, then it's time to bail on this log
              * message
              */
-            if ! continue_rules {
+            if !continue_rules {
                 break;
             }
 
@@ -214,13 +231,12 @@ pub async fn read_logs<R: async_std::io::Read + std::marker::Unpin>(reader: BufR
                         if let Ok(data) = jmespath::Variable::from_json(&msg.msg) {
                             // Search the data with the compiled expression
                             if let Ok(result) = expr.search(data) {
-                                if ! result.is_null() {
+                                if !result.is_null() {
                                     rule_matches = true;
                                     debug!("jmespath rule matched, value: {}", result);
                                     if let Some(value) = result.as_string() {
                                         hash.insert("value".to_string(), value.to_string());
-                                    }
-                                    else {
+                                    } else {
                                         warn!("Unable to parse out the string value for {}, the `value` variable substitution will not be available,", result);
                                     }
                                 }
@@ -237,16 +253,16 @@ pub async fn read_logs<R: async_std::io::Read + std::marker::Unpin>(reader: BufR
                             }
                         }
                     }
-                },
+                }
                 _ => {
                     debug!("unhandled `field` for this rule: {}", rule.regex);
-                },
+                }
             }
 
             /*
              * This specific didn't match, so onto the next one
              */
-            if ! rule_matches {
+            if !rule_matches {
                 continue;
             }
 
@@ -261,7 +277,6 @@ pub async fn read_logs<R: async_std::io::Read + std::marker::Unpin>(reader: BufR
             for action in rule.actions.iter() {
                 match action {
                     Action::Forward { topic } => {
-
                         /*
                          * quick check on our internal queue, if it's full, skip all the processing
                          * and move onto the next message
@@ -290,36 +305,34 @@ pub async fn read_logs<R: async_std::io::Read + std::marker::Unpin>(reader: BufR
                             match state.sender.try_send(kmsg) {
                                 Err(err) => {
                                     error!("Failed to push a message onto our internal Kafka queue: {:?}", err);
-                                },
+                                }
                                 Ok(_) => {
                                     debug!("Message enqueued");
-                                },
+                                }
                             }
                             continue_rules = false;
-                        }
-                        else {
+                        } else {
                             error!("Failed to process the configured topic: `{}`", topic);
                         }
                         break;
-                    },
+                    }
                     Action::Merge { json } => {
                         debug!("merging JSON content: {}", json);
                         if let Ok(buffer) = perform_merge(&msg.msg, json, &rule_state) {
                             output = buffer;
-                        }
-                        else {
+                        } else {
                             continue_rules = false;
                         }
-                    },
+                    }
                     Action::Replace { template } => {
                         debug!("replacing content with template: {}", template);
                         if let Ok(rendered) = hb.render_template(template, &hash) {
                             output = rendered;
                         }
-                    },
+                    }
                     Action::Stop => {
                         continue_rules = false;
-                    },
+                    }
                 }
             }
         }
@@ -328,36 +341,33 @@ pub async fn read_logs<R: async_std::io::Read + std::marker::Unpin>(reader: BufR
     Ok(())
 }
 
-
 /**
  * perform_merge will generate the buffer resulting of the JSON merge
  */
-fn perform_merge(buffer: &str,
+fn perform_merge(
+    buffer: &str,
     to_merge: &serde_json::Value,
-    state: &RuleState) -> std::result::Result<String, String> {
-
+    state: &RuleState,
+) -> std::result::Result<String, String> {
     /*
      * If the administrator configured the merge incorrectly, just pass the buffer along un-merged
      */
-    if ! to_merge.is_object() {
+    if !to_merge.is_object() {
         error!("Merge requested was not a JSON object: {}", to_merge);
         return Ok(buffer.to_string());
     }
 
     if let Ok(mut msg_json) = serde_json::from_str::<serde_json::Value>(buffer) {
-
         merge::merge(&mut msg_json, to_merge);
         if let Ok(output) = serde_json::to_string(&msg_json) {
             if let Ok(rendered) = state.hb.render_template(&output, &state.variables) {
                 return Ok(rendered);
             }
             return Ok(output);
-        }
-        else {
+        } else {
             Err("Failed to render".to_string())
         }
-    }
-    else {
+    } else {
         error!("Failed to parse as JSON, stopping actions: {}", buffer);
 
         Err("Not JSON".to_string())
@@ -368,9 +378,11 @@ fn perform_merge(buffer: &str,
  * merge_and_render will take care of merging the two values and manage the
  * rendering of variable substitutions
  */
-fn merge_and_render<'a>(mut left: &mut serde_json::Value,
+fn merge_and_render<'a>(
+    mut left: &mut serde_json::Value,
     right: &serde_json::Value,
-    state: &RuleState<'a>) -> String {
+    state: &RuleState<'a>,
+) -> String {
     merge::merge(&mut left, &right);
 
     let output = serde_json::to_string(&left).unwrap();
@@ -388,7 +400,6 @@ fn merge_and_render<'a>(mut left: &mut serde_json::Value,
     }
     return output;
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -4,7 +4,6 @@
  *
  * It is licensed under the MIT license
  */
-
 extern crate serde_json;
 
 use serde_json::{Map, Value};

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,21 +1,17 @@
+use crate::settings::*;
 /**
  * Rules processing module
  *
  */
-
-use async_std::{
-    fs::File,
-    io::BufReader,
-    prelude::*,
-    sync::Arc,
-};
-use crate::settings::*;
+use async_std::{fs::File, io::BufReader, prelude::*, sync::Arc};
 use log::*;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 pub async fn test_rules(file_name: &str, settings: Arc<Settings>) -> Result<()> {
-    let file = File::open(file_name).await.expect("Failed to open the file");
+    let file = File::open(file_name)
+        .await
+        .expect("Failed to open the file");
     let reader = BufReader::new(file);
     let mut lines = reader.lines();
     let mut number: u64 = 0;
@@ -34,18 +30,16 @@ pub async fn test_rules(file_name: &str, settings: Arc<Settings>) -> Result<()> 
                         if let Ok(data) = jmespath::Variable::from_json(&line) {
                             // Search the data with the compiled expression
                             if let Ok(result) = expr.search(data) {
-                                if ! result.is_null() {
+                                if !result.is_null() {
                                     matches.push(&rule.jmespath);
                                 }
                             }
                         }
-                    }
-                    else if let Some(_captures) = rule.regex.captures(&line) {
+                    } else if let Some(_captures) = rule.regex.captures(&line) {
                         matches.push(&rule.regex.as_str());
                     }
-                },
-                _ => {
-                },
+                }
+                _ => {}
             }
         }
 
@@ -55,9 +49,7 @@ pub async fn test_rules(file_name: &str, settings: Arc<Settings>) -> Result<()> 
                 println!("\t - {}", m);
             }
         }
-
     }
 
     Ok(())
 }
-

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,6 +8,7 @@ use log::*;
 use regex;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::time::Duration;
 
 pub fn load(file: &str) -> Settings {
     let conf = load_configuration(file);
@@ -111,7 +112,9 @@ pub struct Listen {
 #[derive(Debug, Deserialize)]
 pub struct Kafka {
     #[serde(default = "kafka_buffer_default")]
-    pub buffer: u64,
+    pub buffer: usize,
+    #[serde(default = "kafka_timeout_default")]
+    pub timeout_ms: Duration,
     pub conf: HashMap<String, String>,
     pub topic: String,
 }
@@ -155,8 +158,12 @@ fn empty_str() -> String {
 /**
  * Return the default size used for the Kafka buffer
  */
-fn kafka_buffer_default() -> u64 {
+fn kafka_buffer_default() -> usize {
     1024
+}
+
+fn kafka_timeout_default() -> Duration {
+    Duration::from_secs(30)
 }
 
 #[cfg(test)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,7 +2,6 @@
  * The settings module contains the necessary structs and code to process the
  * hotdog.yml file format
  */
-
 use async_std::path::Path;
 use log::*;
 use regex;
@@ -12,7 +11,8 @@ use std::time::Duration;
 
 pub fn load(file: &str) -> Settings {
     let conf = load_configuration(file);
-    conf.try_into().expect("Failed to parse the configuration file")
+    conf.try_into()
+        .expect("Failed to parse the configuration file")
 }
 
 fn load_configuration(file: &str) -> config::Config {
@@ -58,15 +58,9 @@ pub enum Field {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum Action {
-    Forward {
-        topic: String,
-    },
-    Merge {
-        json: Value,
-    },
-    Replace {
-        template: String,
-    },
+    Forward { topic: String },
+    Merge { json: Value },
+    Replace { template: String },
     Stop,
 }
 
@@ -79,7 +73,6 @@ pub struct Rule {
     #[serde(default = "empty_str")]
     pub jmespath: String,
 }
-
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(untagged)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -79,14 +79,6 @@ pub struct Rule {
     pub jmespath: String,
 }
 
-fn empty_regex() -> regex::Regex {
-    return regex::Regex::new("").unwrap();
-}
-
-fn empty_str() -> String {
-    return String::new();
-}
-
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(untagged)]
@@ -118,6 +110,8 @@ pub struct Listen {
 
 #[derive(Debug, Deserialize)]
 pub struct Kafka {
+    #[serde(default = "kafka_buffer_default")]
+    pub buffer: u64,
     pub conf: HashMap<String, String>,
     pub topic: String,
 }
@@ -140,6 +134,31 @@ pub struct Settings {
     pub rules: Vec<Rule>,
 }
 
+/*
+ * Default functions
+ */
+
+/**
+ * Return an empty regular expression
+ */
+fn empty_regex() -> regex::Regex {
+    return regex::Regex::new("").unwrap();
+}
+
+/**
+ * Allocate an return an empty string
+ */
+fn empty_str() -> String {
+    return String::new();
+}
+
+/**
+ * Return the default size used for the Kafka buffer
+ */
+fn kafka_buffer_default() -> u64 {
+    1024
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -152,5 +171,10 @@ mod tests {
     #[test]
     fn test_empty_str() {
         assert_eq!("".to_string(), empty_str());
+    }
+
+    #[test]
+    fn test_kafka_buffer_default() {
+        assert_eq!(1024, kafka_buffer_default());
     }
 }


### PR DESCRIPTION
This pull request adds two new optional configuration values:

* `global.kafka.buffer` governs the size of the internal queue to buffer log lines into while trying to send to Kafka
* `global.kafka.timeout_ms` governs the connection timeout to Kafka, see #5 