### PR TITLE
Identify and address some performance hot spots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "hotdog"
-version = "0.2.1"
+version = "0.2.0"
 dependencies = [
  "async-std",
  "async-tls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,17 +497,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "handlebars"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,7 +544,6 @@ dependencies = [
  "serde_regex",
  "syslog_loose",
  "syslog_rfc5424",
- "uuid",
 ]
 
 [[package]]
@@ -1033,12 +1021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
-
-[[package]]
 name = "pretty_env_logger"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,47 +1074,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom",
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -1498,15 +1439,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "uuid"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
-dependencies = [
- "rand",
-]
-
-[[package]]
 name = "vcpkg"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,12 +1455,6 @@ name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "hotdog"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-std",
  "async-tls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "handlebars"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +555,7 @@ dependencies = [
  "serde_regex",
  "syslog_loose",
  "syslog_rfc5424",
+ "uuid",
 ]
 
 [[package]]
@@ -1021,6 +1033,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+
+[[package]]
 name = "pretty_env_logger"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1092,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1439,6 +1498,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,6 +1523,12 @@ name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,6 @@ handlebars = "~3.0.1"
 
 # Needed for time management
 chrono = "~0.4.11"
+
+# Needed to tag rules and actions with their own unique identifiers
+uuid = { version = "~0.8.1", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,3 @@ handlebars = "~3.0.1"
 
 # Needed for time management
 chrono = "~0.4.11"
-
-# used for providing internal idenfitiers for templates, etc
-uuid = { version = "~0.8.1", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,6 @@ handlebars = "~3.0.1"
 
 # Needed for time management
 chrono = "~0.4.11"
+
+# used for providing internal idenfitiers for templates, etc
+uuid = { version = "~0.8.1", features = ["v4"] }

--- a/README.adoc
+++ b/README.adoc
@@ -453,6 +453,17 @@ For TLS connections, you can use the `openssl` `s_client` command:
 echo  '<13>1 2020-04-18T15:16:09.956153-07:00 coconut tyler - - [timeQuality tzKnown="1" isSynced="1" syncAccuracy="505061"] hello world' | openssl s_client -connect localhost:6514
 ----
 
+
+=== Profiling
+
+Profiling `hotdog` is best done on a Linux host with the `perf` tool, e.g.
+
+[source,bash]
+----
+RUST_LOG=info perf record --call-graph dwarf -- ./target/debug/hotdog -c ./hotdog.yml
+perf report -ng
+----
+
 == Similar Projects
 
 `hotdog` was originally motivated by challenges with

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -166,7 +166,8 @@ impl Kafka {
                                 Ok(_) => {
                                     timer.stop(handle);
                                     m.counter("kafka.submitted").count(1);
-                                    m.counter(&format!("kafka.submitted.{}", &kmsg.topic)).count(1);
+                                    m.counter(&format!("kafka.submitted.{}", &kmsg.topic))
+                                        .count(1);
                                 }
                                 Err((err, _)) => {
                                     match err {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,13 @@ extern crate regex;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+#[cfg(test)]
+#[macro_use]
+extern crate serde_json;
 extern crate serde_regex;
 extern crate syslog_rfc5424;
 extern crate syslog_loose;
+extern crate uuid;
 
 use async_std::{
     io::BufReader,
@@ -45,10 +49,11 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>
 /**
  * ConnectionState carries the necessary types of state into new tasks for handling connections
  */
-pub struct ConnectionState {
+pub struct ConnectionState<'a> {
     settings: Arc<Settings>,
     metrics: Arc<StatsdScope>,
     sender: Sender<KafkaMessage>,
+    hb: Arc<Handlebars<'a>>,
 }
 
 /**
@@ -88,7 +93,11 @@ fn main() -> Result<()> {
         .get_matches();
 
     let settings_file = matches.value_of("config").unwrap_or("hotdog.yml");
-    let settings = Arc::new(settings::load(settings_file));
+    let mut settings = settings::load(settings_file);
+    let mut hb = Handlebars::new();
+    settings.prerender_templates(&mut hb);
+
+    let settings = Arc::new(settings);
 
     if let Some(test_file) = matches.value_of("test") {
         return task::block_on(rules::test_rules(&test_file, settings));
@@ -118,11 +127,12 @@ fn main() -> Result<()> {
                 addr,
                 settings.clone(),
                 metrics,
+                hb,
             ))
         }
         _ => {
             info!("Serving in plaintext mode");
-            task::block_on(accept_loop(addr, settings.clone(), metrics))
+            task::block_on(accept_loop(addr, settings.clone(), metrics, hb))
         }
     }
 }
@@ -131,11 +141,13 @@ fn main() -> Result<()> {
  * accept_loop will simply create the socket listener and dispatch newly accepted connections to
  * the connection_loop function
  */
-async fn accept_loop(
+async fn accept_loop<'a>(
     addr: impl ToSocketAddrs,
     settings: Arc<Settings>,
     metrics: Arc<StatsdScope>,
+    hb: Handlebars<'a>
 ) -> Result<()> {
+    let hb = Arc::new(hb);
     let mut kafka = Kafka::new(settings.global.kafka.buffer);
 
     if !kafka.connect(
@@ -164,6 +176,7 @@ async fn accept_loop(
             settings: settings.clone(),
             metrics: metrics.clone(),
             sender: sender.clone(),
+            hb: hb.clone(),
         };
 
         task::spawn(async move {
@@ -180,9 +193,9 @@ async fn accept_loop(
  * connection_loop is responsible for handling incoming syslog streams connections
  *
  */
-pub async fn read_logs<R: async_std::io::Read + std::marker::Unpin>(
+pub async fn read_logs<'a, R: async_std::io::Read + std::marker::Unpin>(
     reader: BufReader<R>,
-    state: ConnectionState,
+    state: ConnectionState<'a>,
 ) -> Result<()> {
     let mut lines = reader.lines();
     let lines_count = state.metrics.counter("lines");
@@ -327,7 +340,7 @@ pub async fn read_logs<R: async_std::io::Read + std::marker::Unpin>(
                         }
                         break;
                     }
-                    Action::Merge { json, json_str } => {
+                    Action::Merge { json, json_str, template_id } => {
                         if let Some(json_str) = json_str {
                             debug!("merging JSON content: {}", json);
                             if let Ok(buffer) = perform_merge(&msg.msg, json_str, &rule_state) {
@@ -340,7 +353,7 @@ pub async fn read_logs<R: async_std::io::Read + std::marker::Unpin>(
                             error!("Merge action contained no cached json-str for {}", json);
                         }
                     }
-                    Action::Replace { template } => {
+                    Action::Replace { template, template_id: _ } => {
                         debug!("replacing content with template: {}", template);
                         if let Ok(rendered) = hb.render_template(template, &hash) {
                             output = rendered;

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,10 @@ fn precompile_templates(hb: &mut Handlebars, settings: Arc<Settings>) -> bool {
                     let template_id = template_id_for(rule, index);
 
                     if let Some(template) = json_str {
-                        hb.register_template_string(&template_id, &template);
+                        if let Err(e) = hb.register_template_string(&template_id, &template) {
+                            error!("Failed to register template! {}\n{}", e, template);
+                            return false;
+                        }
                     } else {
                         error!("Could not look up the json_str for a Merge action");
                         return false;
@@ -203,8 +206,10 @@ fn precompile_templates(hb: &mut Handlebars, settings: Arc<Settings>) -> bool {
                 }
                 Action::Replace { template } => {
                     let template_id = format!("{}-{}", rule.uuid, index);
-
-                    hb.register_template_string(&template_id, &template);
+                    if let Err(e) = hb.register_template_string(&template_id, &template) {
+                        error!("Failed to register template! {}\n{}", e, template);
+                        return false;
+                    }
                 }
                 _ => {}
             }
@@ -468,7 +473,7 @@ mod tests {
         RuleState {
             hb: &hb,
             variables: &hash,
-            metrics: metrics,
+            metrics,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -425,40 +425,6 @@ fn perform_merge(
     }
 }
 
-/**
- * Render all the (string) values of the given serde Map as if they were handlebars templates
- */
-fn render_value<'a>(mut value: serde_json::Value,
-                hb: &'a handlebars::Handlebars<'a>,
-                vars: &'a HashMap<String, String>) -> serde_json::Value {
-
-    if value.is_string() {
-        if let Ok(rendered) = hb.render_template(value.as_str().unwrap(), vars) {
-            return serde_json::Value::String(rendered);
-        }
-    }
-    if value.is_array() {
-        let mut converted: Vec<serde_json::Value> = vec![];
-
-        for val in value.as_array().unwrap() {
-            converted.push(render_value(val.clone(), hb, vars));
-        };
-
-        return serde_json::Value::Array(converted);
-    }
-    if value.is_object() {
-        let mut obj = serde_json::map::Map::new();
-        let value_obj = value.as_object_mut().unwrap();
-
-        for key in value_obj.keys() {
-            obj.insert(key.to_string(),
-                    render_value(value_obj[key].clone(), hb, vars));
-        }
-        return serde_json::Value::Object(obj);
-    }
-    value
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -581,53 +547,5 @@ mod tests {
         if let Ok(msg) = parsed {
             assert_eq!("hi", msg.msg);
         }
-    }
-
-    /**
-     * Rendering a string value should be parsed and returned back with variables
-     * substituted
-     */
-    #[test]
-    fn test_render_value_string() {
-        let hb = Handlebars::new();
-        let mut hash = HashMap::<String, String>::new();
-        hash.insert(String::from("name"), String::from("ferris"));
-
-        let val: serde_json::Value = json!("hello {{name}}");
-        let rval = render_value(val, &hb, &hash);
-        assert_eq!(rval.to_string(), r#""hello ferris""#);
-    }
-
-    #[test]
-    fn test_render_value_array() {
-        let hb = Handlebars::new();
-        let mut hash = HashMap::<String, String>::new();
-        hash.insert(String::from("name"), String::from("ferris"));
-
-        let val: serde_json::Value = json!(["hello", "{{name}}"]);
-        let rval = render_value(val, &hb, &hash);
-        assert_eq!(rval.to_string(), r#"["hello","ferris"]"#);
-    }
-
-    #[test]
-    fn test_render_value_object() {
-        let hb = Handlebars::new();
-        let mut hash = HashMap::<String, String>::new();
-        hash.insert(String::from("name"), String::from("ferris"));
-
-        let val: serde_json::Value = json!({"hello" : "{{name}}"});
-        let rval = render_value(val, &hb, &hash);
-        assert_eq!(rval.to_string(), r#"{"hello":"ferris"}"#);
-    }
-
-    #[test]
-    fn test_render_value_nested_object() {
-        let hb = Handlebars::new();
-        let mut hash = HashMap::<String, String>::new();
-        hash.insert(String::from("name"), String::from("ferris"));
-
-        let val: serde_json::Value = json!({"hello" : {"nested" : "{{name}}"}});
-        let rval = render_value(val, &hb, &hash);
-        assert_eq!(rval.to_string(), r#"{"hello":{"nested":"ferris"}}"#);
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,80 @@
+
+/**
+ * Enum of syslog parse related errors
+ */
+#[derive(Debug)]
+pub enum SyslogErrors {
+    UnknownFormat,
+}
+
+/**
+ * SyslogMessage is just a wrapper struct to allow us to deserialize RFC 5424 and RFC 3164 syslog
+ * messages into some format that can be passed throughout hotdog
+ */
+#[derive(Debug)]
+pub struct SyslogMessage {
+   pub msg: String,
+}
+
+/**
+ * Attempt to parse a given line either as RFC 5424 or RFC 3164
+ */
+pub fn parse_line(line: String) -> std::result::Result<SyslogMessage, SyslogErrors> {
+    match syslog_rfc5424::parse_message(&line) {
+        Ok(msg) => {
+            return Ok(SyslogMessage {
+                msg: msg.msg,
+            })
+        },
+        Err(_) => {
+            let parsed = syslog_loose::parse_message(&line);
+
+            /*
+             * Since syslog_loose doesn't give a Result, the only way to tell if themessage wasn't
+             * parsed properly is if some fields are None'd out.
+             */
+            if parsed.timestamp != None {
+                return Ok(SyslogMessage{
+                    msg: parsed.msg.to_string(),
+                })
+            }
+            Err(SyslogErrors::UnknownFormat)
+        },
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parsing_invalid() {
+        let buffer = "blah".to_string();
+        let parsed = parse_line(buffer);
+        if let Ok(msg) = &parsed {
+            println!("msg: {}", msg.msg);
+        }
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn test_5424() {
+        let buffer = r#"<13>1 2020-04-18T15:16:09.956153-07:00 coconut tyler - - [timeQuality tzKnown="1" isSynced="1" syncAccuracy="505061"] hi"#.to_string();
+        let parsed = parse_line(buffer);
+        assert!(parsed.is_ok());
+        if let Ok(msg) = parsed {
+            assert_eq!("hi", msg.msg);
+        }
+    }
+
+    #[test]
+    fn test_3164() {
+        let buffer = r#"<190>May 13 21:45:18 coconut hotdog: hi"#.to_string();
+        let parsed = parse_line(buffer);
+        assert!(parsed.is_ok());
+        if let Ok(msg) = parsed {
+            assert_eq!("hi", msg.msg);
+        }
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -20,7 +20,7 @@ pub struct SyslogMessage {
  */
 pub fn parse_line(line: String) -> std::result::Result<SyslogMessage, SyslogErrors> {
     match syslog_rfc5424::parse_message(&line) {
-        Ok(msg) => return Ok(SyslogMessage { msg: msg.msg }),
+        Ok(msg) => Ok(SyslogMessage { msg: msg.msg }),
         Err(_) => {
             let parsed = syslog_loose::parse_message(&line);
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,4 +1,3 @@
-
 /**
  * Enum of syslog parse related errors
  */
@@ -13,7 +12,7 @@ pub enum SyslogErrors {
  */
 #[derive(Debug)]
 pub struct SyslogMessage {
-   pub msg: String,
+    pub msg: String,
 }
 
 /**
@@ -21,11 +20,7 @@ pub struct SyslogMessage {
  */
 pub fn parse_line(line: String) -> std::result::Result<SyslogMessage, SyslogErrors> {
     match syslog_rfc5424::parse_message(&line) {
-        Ok(msg) => {
-            return Ok(SyslogMessage {
-                msg: msg.msg,
-            })
-        },
+        Ok(msg) => return Ok(SyslogMessage { msg: msg.msg }),
         Err(_) => {
             let parsed = syslog_loose::parse_message(&line);
 
@@ -34,15 +29,14 @@ pub fn parse_line(line: String) -> std::result::Result<SyslogMessage, SyslogErro
              * parsed properly is if some fields are None'd out.
              */
             if parsed.timestamp != None {
-                return Ok(SyslogMessage{
+                return Ok(SyslogMessage {
                     msg: parsed.msg.to_string(),
-                })
+                });
             }
             Err(SyslogErrors::UnknownFormat)
-        },
+        }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,7 +11,9 @@ use uuid::Uuid;
 
 pub fn load(file: &str) -> Settings {
     let conf = load_configuration(file);
-    let mut settings: Settings = conf.try_into().expect("Failed to parse the configuration file");
+    let mut settings: Settings = conf
+        .try_into()
+        .expect("Failed to parse the configuration file");
     settings.populate_caches();
     settings
 }
@@ -59,13 +61,17 @@ pub enum Field {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum Action {
-    Forward { topic: String },
+    Forward {
+        topic: String,
+    },
     Merge {
         json: Value,
         #[serde(default = "default_none")]
         json_str: Option<String>,
     },
-    Replace { template: String },
+    Replace {
+        template: String,
+    },
     Stop,
 }
 
@@ -73,10 +79,10 @@ impl Action {
     fn populate_caches(&mut self) {
         match self {
             Action::Merge { json, json_str } => {
-                *json_str = Some(serde_json::to_string(json).expect("Failed to serialize Merge action"));
-            },
-            _ => {
-            },
+                *json_str =
+                    Some(serde_json::to_string(json).expect("Failed to serialize Merge action"));
+            }
+            _ => {}
         }
     }
 }
@@ -215,7 +221,7 @@ mod tests {
         match &settings.rules[0].actions[0] {
             Action::Merge { json: _, json_str } => {
                 assert!(json_str.is_some());
-            },
+            }
             _ => {
                 assert!(false);
             }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -77,12 +77,9 @@ pub enum Action {
 
 impl Action {
     fn populate_caches(&mut self) {
-        match self {
-            Action::Merge { json, json_str } => {
-                *json_str =
-                    Some(serde_json::to_string(json).expect("Failed to serialize Merge action"));
-            }
-            _ => {}
+        if let Action::Merge { json, json_str } = self {
+            *json_str =
+                Some(serde_json::to_string(json).expect("Failed to serialize Merge action"));
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,6 +7,7 @@ use log::*;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::time::Duration;
+use uuid::Uuid;
 
 pub fn load(file: &str) -> Settings {
     let conf = load_configuration(file);
@@ -82,6 +83,8 @@ impl Action {
 
 #[derive(Debug, Deserialize)]
 pub struct Rule {
+    #[serde(skip_serializing, skip_deserializing, default = "default_uuid")]
+    pub uuid: Uuid,
     pub field: Field,
     pub actions: Vec<Action>,
     #[serde(with = "serde_regex", default = "default_none")]
@@ -192,6 +195,10 @@ fn default_none<T>() -> Option<T> {
     None
 }
 
+fn default_uuid() -> Uuid {
+    Uuid::new_v4()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -228,5 +235,10 @@ mod tests {
     #[test]
     fn test_kafka_buffer_default() {
         assert_eq!(1024, kafka_buffer_default());
+    }
+
+    #[test]
+    fn test_default_uuid() {
+        assert_eq!(false, default_uuid().is_nil());
     }
 }

--- a/test/configs/single-rule-with-merge.yml
+++ b/test/configs/single-rule-with-merge.yml
@@ -1,0 +1,27 @@
+# A simple test configuration for verifiying some Merge action behavior
+---
+global:
+  listen:
+    address: '127.0.0.1'
+    port: 514
+    tls:
+  kafka:
+    conf:
+      bootstrap.servers: '127.0.0.1:9092'
+    # Default topic to log messages to that are not otherwise mapped
+    topic: 'test'
+  metrics:
+    statsd: 'localhost:8125'
+
+rules:
+  # Match JSON content which has a meta.topic value, e.g.
+  #   {"meta":{"topic" : "foo"}}
+  - jmespath: 'meta.topic'
+    field: msg
+    actions:
+      - type: merge
+        json:
+          meta:
+            hotdog:
+              version: '{{version}}'
+              timestamp: '{{iso8601}}'

--- a/test/configs/single-rule-with-replace.yml
+++ b/test/configs/single-rule-with-replace.yml
@@ -1,0 +1,24 @@
+# A simple test configuration for verifiying some Replace action behavior
+---
+global:
+  listen:
+    address: '127.0.0.1'
+    port: 514
+    tls:
+  kafka:
+    conf:
+      bootstrap.servers: '127.0.0.1:9092'
+    # Default topic to log messages to that are not otherwise mapped
+    topic: 'test'
+  metrics:
+    statsd: 'localhost:8125'
+
+rules:
+  - regex: '^hello\s+(?P<name>\w+)?'
+    field: msg
+    actions:
+      - type: replace
+        template: |
+          This is the total message: {{msg}}
+
+          And the name is: {{name}}


### PR DESCRIPTION
I don't have a great benchmark suite to compare different releases of :hotdog: to one another.

To improve performance I was mostly looking at `perf` results and comparing one run to another.


The closest comparison that I can run is between `master` and this branch with my `client.rb` script which sends 10k JSON events along.

*master*
```
time: /target/debug/hotdog  18.77s user 1.85s system 82% cpu 24.907 total 
time: ruby client.rb  0.31s user 0.04s system 2% cpu 16.642 total
```

*this branch*
```
time: ./target/debug/hotdog  12.56s user 1.24s system 34% cpu 40.219 total 
time: ruby client.rb  0.30s user 0.05s system 3% cpu 10.180 total
```

This is obviously lacking in any serious performance analysis rigor, but I feel pretty confident that the overall CPU usage was definitely improved with some of these changes.

This pull request closes #26 