### PR TITLE
Implement support for matching rules on different fields

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -79,15 +79,15 @@ example:
 ----
 ❯ RUST_LOG=info ./target/debug/hotdog -t example.log
 Line 1 matches on:
-         - ^hello\s+(?P<name>\w+)?
-         - .*
+         - Regex: ^hello\s+(?P<name>\w+)?
+         - Regex: .*
 Line 2 matches on:
-         - .*
+         - Regex: .*
 Line 3 matches on:
-         - .*
+         - Regex: .*
 Line 4 matches on:
-         - ^\{(.*)?\}$
-         - .*
+         - JMESPath: meta.topic
+         - Regex: .*
 ----
 
 [[global]]
@@ -249,6 +249,27 @@ rules:
       - type: forward
         topic: 'logs-unknown'
 ----
+
+.Supported Fields
+|===
+| Name | Notes
+
+| `msg`
+| The actual message sent along from the syslog server
+
+| `hostname`
+| The sender's hostname, if available.
+
+| `appname`
+| The logging application, if available, which created the syslog entry
+
+| `facility`
+| The syslog logging facility, if available, which was used to create the syslog message. For example `kern`, `user`, `auth`, etc.
+
+| `severity`
+| The severity of the syslog message, if available. For example: `notice`, `err`, `crit`, etc.
+
+|===
 
 [[rules-regex]]
 ==== Matching with regular expressions

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -47,12 +47,16 @@ fn load_configuration(file: &str) -> config::Config {
     conf
 }
 
+/**
+ * Valid field to apply the rule upon
+ *
+ * They should be camel-cased in the yaml configuration
+ */
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum Field {
     Severity,
     Facility,
-    Timestamp,
     Hostname,
     Appname,
     Msg,
@@ -101,6 +105,16 @@ impl Rule {
         self.actions.iter_mut().for_each(|action| {
             action.populate_caches();
         });
+    }
+}
+impl std::fmt::Display for Rule {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        if let Some(regex) = &self.regex {
+            write!(f, "Regex: {}", regex)
+        }
+        else {
+            write!(f, "JMESPath: {}", self.jmespath)
+        }
     }
 }
 

--- a/test/configs/single-rule-with-hostname-field.yml
+++ b/test/configs/single-rule-with-hostname-field.yml
@@ -1,0 +1,40 @@
+# A simple test configuration for verifiying field based routing
+---
+global:
+  listen:
+    address: '127.0.0.1'
+    port: 1514
+    tls:
+  kafka:
+    conf:
+      bootstrap.servers: '127.0.0.1:9092'
+    # Default topic to log messages to that are not otherwise mapped
+    topic: 'test'
+  metrics:
+    statsd: 'localhost:8125'
+
+rules:
+  - regex: '^coconut$'
+    field: hostname
+    actions:
+      - type: replace
+        template: |
+          This messages was received by my workstation
+
+          {{msg}}
+
+      - type: forward
+        topic: test
+
+  - regex: '.*'
+    field: hostname
+    actions:
+      - type: replace
+        template: |
+          This message NOT received properly
+
+          {{msg}}
+
+      - type: forward
+        topic: test
+


### PR DESCRIPTION
Right now this only supports a subset of the total fields available in syslog to
keep things simple since :hotdog: is supporting both RFC 5424 and RFC 3164
syslog. :scream_cat:

Fixes #15