### PR TITLE
Implement per-connection caching of JMESPath compilations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,9 @@ serde_regex = "~0.4.0"
 regex = "~1.3.6"
 
 # used for rule matching on JSON
-jmespath = { git = "https://github.com/jmespath/jmespath.rs" }
+#  The "sync" feature is undocumented but required in order to swap Rc for Arc
+#  in the crate, allowing it to be used with futures and threads properly
+jmespath = { git = "https://github.com/jmespath/jmespath.rs", features = ["sync"] }
 
 # Needed to report metrics of hotdog's performance
 dipstick = "~0.8.0"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -96,8 +96,9 @@ pub struct Rule {
     pub actions: Vec<Action>,
     #[serde(with = "serde_regex", default = "default_none")]
     pub regex: Option<regex::Regex>,
-    #[serde(default = "empty_str")]
-    pub jmespath: String,
+    #[serde(default = "default_none")]
+    pub jmespath: Option<String>,
+
 }
 
 impl Rule {
@@ -113,7 +114,7 @@ impl std::fmt::Display for Rule {
             write!(f, "Regex: {}", regex)
         }
         else {
-            write!(f, "JMESPath: {}", self.jmespath)
+            write!(f, "JMESPath: {}", self.jmespath.as_ref().unwrap())
         }
     }
 }
@@ -191,13 +192,6 @@ impl Settings {
  */
 
 /**
- * Allocate an return an empty string
- */
-fn empty_str() -> String {
-    String::new()
-}
-
-/**
  * Return the default size used for the Kafka buffer
  */
 fn kafka_buffer_default() -> usize {
@@ -242,11 +236,6 @@ mod tests {
     #[test]
     fn test_default_tls() {
         assert_eq!(TlsType::None, TlsType::default());
-    }
-
-    #[test]
-    fn test_empty_str() {
-        assert_eq!("".to_string(), empty_str());
     }
 
     #[test]

--- a/test/configs/single-rule-with-invalid-jmespath.yml
+++ b/test/configs/single-rule-with-invalid-jmespath.yml
@@ -1,0 +1,27 @@
+# A simple test configuration for verifiying some Merge action behavior
+---
+global:
+  listen:
+    address: '127.0.0.1'
+    port: 514
+    tls:
+  kafka:
+    conf:
+      bootstrap.servers: '127.0.0.1:9092'
+    # Default topic to log messages to that are not otherwise mapped
+    topic: 'test'
+  metrics:
+    statsd: 'localhost:8125'
+
+rules:
+  # Match JSON content which has a meta.topic value, e.g.
+  #   {"meta":{"topic" : "foo"}}
+  - jmespath: '. 0 meta.topic'
+    field: msg
+    actions:
+      - type: merge
+        json:
+          meta:
+            hotdog:
+              version: '{{version}}'
+              timestamp: '{{iso8601}}'


### PR DESCRIPTION
This should further reduce the amount of CPU time spent per log line

Fixes #32